### PR TITLE
Added settings to allow customized Symfony structures

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,6 +8,7 @@ Configuration
 -------------
 Edit the settings.php file and the following lines :
 
+```php
     $conf['symfony2'] = array(
         'root'  => __DIR__.'/../..', // the project root path
         'drush' => array(
@@ -15,6 +16,23 @@ Edit the settings.php file and the following lines :
             'debug' => true
         )
     );
+```
+
+In the case you have a customized Symfony structure, you can add a `kernel_factory` array key and create a custom closure
+that will return the kernal class name:
+
+```php
+
+$conf['symfony2']['kernel_factory'] = function (array $conf) {
+    $kernelName = 'PortalKernel';
+
+    require_once sprintf('%s/apps/bootstrap.php.cache', $conf['symfony2']['root']);
+    require_once sprintf('%s/apps/BaseKernel.php', $conf['symfony2']['root']);
+    require_once sprintf('%s/apps/portal/%s.php', $conf['symfony2']['root'], $kernelName);
+
+    return $kernelName;
+};
+```
 
 Hooks
 -----

--- a/ekino_drupal_symfony2.module
+++ b/ekino_drupal_symfony2.module
@@ -8,7 +8,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 if (PHP_SAPI === 'cli' && !defined('EKINO_DRUSH_FROM')) {
   ekino_drupal_symfony_start('drush');
 }
@@ -22,13 +21,19 @@ function ekino_drupal_symfony_start($mode)
   global $container, $conf;
 
   if (!$container && PHP_SAPI === 'cli' && $mode == 'drush') {
-    require_once sprintf('%s/%s/bootstrap.php.cache', $conf['symfony2']['root'], 'app');
-    require_once sprintf('%s/%s/AppKernel.php', $conf['symfony2']['root'], 'app');
+    if (!isset($conf['symfony2']['kernel_factory'])) {
+      require_once sprintf('%s/%s/bootstrap.php.cache', $conf['symfony2']['root'], 'app');
+      require_once sprintf('%s/%s/AppKernel.php', $conf['symfony2']['root'], 'app');
+
+      $kernelName = 'AppKernel';
+    } else {
+      $kernelName = $conf['symfony2']['kernel_factory']($conf);
+    }
 
     echo "[Symfony2] Booting Kernel ";
 
     $content = ob_get_flush();
-    $kernel = new AppKernel($conf['symfony2'][$mode]['env'], $conf['symfony2'][$mode]['debug']);
+    $kernel = new $kernelName($conf['symfony2'][$mode]['env'], $conf['symfony2'][$mode]['debug']);
     $kernel->loadClassCache();
     $kernel->boot();
 


### PR DESCRIPTION
I've updated the module to work properly with Symfony customized structures, when using a multi-kernel structure for instance.

Let's take the following structure:

```bash
apps
    |- bootstrap.php.cache
    |- BaseKernel.php
    |- portal
       |- PortalKernel.php (extends BaseKernel.php)
```

Module doesn't work properly as it is looking for a hard-coded `bootstrap.php.cache` and `AppKernel.php` in the `app` directory.

We can now customize those settings with the following php array configuration (by adding a new optional `kernel_factory` key entry):

```php
$conf['symfony2'] = array(
    'kernel_factory' => function (array $conf) { // optional for customized Symfony structures
        $kernelName = 'PortalKernel';

        require_once sprintf('%s/apps/bootstrap.php.cache', $conf['symfony2']['root']);
        require_once sprintf('%s/apps/BaseKernel.php', $conf['symfony2']['root']);
        require_once sprintf('%s/apps/portal/%s.php', $conf['symfony2']['root'], $kernelName);

        return $kernelName;
    },
    'root'  => __DIR__.'/../..',
    'drush' => array(
            'env'   => 'prod',
            'debug' => true,
    )
);
```