### PR TITLE
fix: avoid useless loadClassCache() method call with PHP 7+

### DIFF
--- a/ekino_drupal_symfony2.module
+++ b/ekino_drupal_symfony2.module
@@ -34,7 +34,11 @@ function ekino_drupal_symfony_start($mode)
 
     $content = ob_get_flush();
     $kernel = new $kernelName($conf['symfony2'][$mode]['env'], $conf['symfony2'][$mode]['debug']);
-    $kernel->loadClassCache();
+
+    if (\PHP_VERSION_ID < 70000) {
+      $kernel->loadClassCache();
+    }
+
     $kernel->boot();
 
     echo " ... ok! \n";


### PR DESCRIPTION
> Thanks to the optimizations introduced in PHP 7, bootstrap files are no longer necessary when running your Symfony applications with PHP 7 or a newer PHP version.